### PR TITLE
Use Revised Layoff field for IL jobs number

### DIFF
--- a/warn_transformer/transformers/il.py
+++ b/warn_transformer/transformers/il.py
@@ -9,7 +9,7 @@ class Transformer(BaseTransformer):
         company="Location Name",
         location=lambda row: f"{row['Location Address']} {row['Location City']}, {row['Location State']} {row['Location Zipcode']}".strip(),
         date=lambda row: row["Initial Date Reported"] or row["Notify Date"],
-        jobs="Total # of Employees",
+        jobs="Revised Layoff",
     )
     date_format = "%Y-%m-%d %H:%M:%S"
     minimum_year = 1987


### PR DESCRIPTION
Currently uses total employees, this uses a revised count of laid off employees instead.

Closes #75 